### PR TITLE
Export DEVSHIFT_TAG_LEN in cico_setup

### DIFF
--- a/.cico/setup.sh
+++ b/.cico/setup.sh
@@ -30,6 +30,7 @@ function setup() {
                 ghprbGhRepository \
                 ghprbPullId \
                 GIT_COMMIT \
+                DEVSHIFT_TAG_LEN \
                 QUAY_USERNAME \
                 QUAY_PASSWORD \
                 BUILD_URL \


### PR DESCRIPTION
So we can cut the image to that length.

This closes openshiftio/openshift.io#4499 and closes #53