### PR TITLE
Don't wrap deploy with an error catcher

### DIFF
--- a/.cico/setup.sh
+++ b/.cico/setup.sh
@@ -57,8 +57,7 @@ function tag_push() {
     buildah push --creds "${QUAY_USERNAME}:${QUAY_PASSWORD}" ${image}:${tag} ${image}:${tag}
 }
 
-
-function _deploy() {
+function deploy() {
   # Login first
   cd ${REPO_PATH}
 
@@ -75,17 +74,6 @@ function _deploy() {
   fi
 
   echo 'CICO: Image pushed, ready to update deployed app'
-}
-
-
-function deploy() {
-    set +e
-    _deploy || fail=true
-    set -e
-
-    if [[ -n ${fail} ]];then
-		echo "We need to find a way to notify that something has failed"
-    fi
 }
 
 function check_up() {


### PR DESCRIPTION
We were not using it since we don't know where to send the error yet
and it would not fail gracefully.

Probably if we need to replace this, we would just use a trap function.

This closes openshiftio/openshift.io#4530 and closes #71