### PR TITLE
Don't start container automatically on unit-test

### DIFF
--- a/.cico/setup.sh
+++ b/.cico/setup.sh
@@ -113,7 +113,10 @@ function dotest() {
 
     make container-run
 
-    check_up postgres-build 127.0.0.1 5433
+    eval $(make print-env|grep '^DB_CONTAINER_PORT')
+    export F8_POSTGRES_PORT="${DB_CONTAINER_PORT}"
+
+    check_up postgres-build 127.0.0.1 ${DB_CONTAINER_PORT}
 
     make test-unit
 

--- a/Makefile
+++ b/Makefile
@@ -119,10 +119,9 @@ endif
 # Unittest
 # -------------------------------------------------------------------
 .PHONY: test-unit
-test-unit: prebuild-check $(SOURCES) container-run generate ## Runs the unit tests and WITHOUT producing coverage files for each package.
+test-unit: prebuild-check $(SOURCES) generate ## Runs the unit tests and WITHOUT producing coverage files for each package.
 	$(call log-info,"Running test: $@")
 	$(eval TEST_PACKAGES:=$(shell go list ./... | grep -v $(ALL_PKGS_EXCLUDE_PATTERN)))
-	F8_POSTGRES_PORT="$(DB_CONTAINER_PORT)" \
 	F8_RESOURCE_UNIT_TEST=1 F8_RESOURCE_DATABASE=1 F8_DEVELOPER_MODE_ENABLED=1 \
 	F8_LOG_LEVEL=$(F8_LOG_LEVEL) \
 	go test -v $(GO_TEST_VERBOSITY_FLAG) $(TEST_PACKAGES)


### PR DESCRIPTION
Let it set manually before (port-forward or container-run)