### PR TITLE
Run the tests on deployment as well

### DIFF
--- a/.cico/deploy.sh
+++ b/.cico/deploy.sh
@@ -7,4 +7,7 @@ source .cico/setup.sh
 
 setup
 
+# Do the test on deploy if it become too slow separate it to another job i.e: https://git.io/fpCrg
+dotest
+
 deploy


### PR DESCRIPTION
So we can get the coverage base from master there as well,

We could have as well have another job in cico for this like done on other
fabric8-services (i.e: https://git.io/fpCrg ) but let do that perhaps if this
the merge job become too slow in the future.

This closes openshiftio/openshift.io#4556 and closes #85