### PR TITLE
Disable megacheck again

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -9,6 +9,7 @@ linters:
     - lll
     - gosec
     - prealloc
+    - megacheck
   enable-all: true
 
 issues:


### PR DESCRIPTION
This has proven buggy again in CI :

```
[runner/megacheck] Can't run megacheck because of compilation
errors in packages [github.com/fabric8-services/fabric8-build/test/doubles
github.com/fabric8-services/fabric8-build/auth
[github.com/fabric8-services/fabric8-build/auth.test]
github.com/fabric8-services/fabric8-build/auth_test
[github.com/fabric8-services/fabric8-build/auth.test]
github.com/fabric8-services/fabric8-build/configuration
[github.com/fabric8-services/fabric8-build/configuration.test]
github.com/fabric8-services/fabric8-build/configuration_test
[github.com/fabric8-services/fabric8-build/configuration.test]
github.com/fabric8-services/fabric8-build/migration
[github.com/fabric8-services/fabric8-build/migration.test]
github.com/fabric8-services/fabric8-build/migration_test
[github.com/fabric8-services/fabric8-build/migration.test]
github.com/fabric8-services/fabric8-build/design
github.com/fabric8-services/fabric8-build/gormapp
github.com/fabric8-services/fabric8-build/test
github.com/fabric8-services/fabric8-build/test/recorder
github.com/fabric8-services/fabric8-build/app/test
github.com/fabric8-services/fabric8-build/auth/client
github.com/fabric8-services/fabric8-build/controller
[github.com/fabric8-services/fabric8-build/controller.test]
github.com/fabric8-services/fabric8-build/controller_test
[github.com/fabric8-services/fabric8-build/controller.test]
github.com/fabric8-services/fabric8-build/app
[github.com/fabric8-services/fabric8-build/app.test]
github.com/fabric8-services/fabric8-build/application
github.com/fabric8-services/fabric8-build
github.com/fabric8-services/fabric8-build/build
[github.com/fabric8-services/fabric8-build/build.test]
github.com/fabric8-services/fabric8-build/build_test
[github.com/fabric8-services/fabric8-build/build.test]]:
test/doubles/test_doubles.go:1:
/tmp/gopackages526386534/go-build/net/cgo_linux.cgo1.go:1: no such file or
directory and 167 more errors: run `golangci-lint run --no-config --disable-all
-E typecheck` to see all errors
```