### PR TITLE
Handle conflicts properly by issuing a 509

### DIFF
--- a/build/pipelineenv.go
+++ b/build/pipelineenv.go
@@ -2,6 +2,7 @@ package build
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/fabric8-services/fabric8-common/errors"
@@ -48,6 +49,10 @@ func (r *GormRepository) Create(ctx context.Context, pipl *Pipeline) (*Pipeline,
 
 	err := r.db.Create(pipl).Error
 	if err != nil {
+		if gormsupport.IsUniqueViolation(err, "pipelines_name_space_id_key") {
+			return nil, errors.NewDataConflictError(fmt.Sprintf("pipeline_name %s with spaceID %s already exists", *pipl.Name, pipl.SpaceID))
+		}
+
 		log.Error(ctx, map[string]interface{}{"err": err},
 			"unable to create pipeline")
 		return nil, errs.WithStack(err)

--- a/design/pipelineenv.go
+++ b/design/pipelineenv.go
@@ -48,6 +48,7 @@ var _ = a.Resource("PipelineEnvironments", func() {
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.MethodNotAllowed, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
 	})
 
 	a.Action("show", func() {

--- a/migration/sql-files/001-pipelineenv.sql
+++ b/migration/sql-files/001-pipelineenv.sql
@@ -5,9 +5,10 @@ CREATE TABLE pipelines (
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
     id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
-    name text UNIQUE NOT NULL,
+    name text NOT NULL,
     space_id uuid,
-    PRIMARY KEY(id)
+    PRIMARY KEY(id),
+    UNIQUE(name, space_id)
 );
 
 


### PR DESCRIPTION
Let set the uniqueness on the name, spaceID association.

To test this PR you would need to make sure to `make regenerate` so you
regenerate the sqlbindata and reinitialise your postgres DB as well (i.e: `psql
template1 -c 'drop database postgres' -c 'create database postgres'`). We are
not doing migrations stuf yet until it's ready for deployment,

This closes openshiftio/openshift.io#4578 and closes #106