### PR TITLE
Remove make analyze-go-code from ci

### DIFF
--- a/.cico/setup.sh
+++ b/.cico/setup.sh
@@ -118,5 +118,4 @@ function do_coverage() {
 
 function do_test() {
     make test-unit
-    make analyze-go-code
 }


### PR DESCRIPTION
This is now handled direclty by the golangci.com web service