### PR TITLE
Reenable all golangci linters and fix the remaining errors

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -5,13 +5,6 @@ run:
     - design/*
 linters:
   fast: true
-  disable:
-    # typecheck errors due to https://github.com/goadesign/goa/issues/1850,
-    # need to update to goagen >= 1.4.0
-    - typecheck
-    - lll
-    - prealloc
-    - gosec
 service:
   project-path: github.com/fabric8-services/fabric8-build
   prepare:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ go (>=1.8), git, make, dep
 * `make container-run` will start a DB container into docker
 * `make coverage` will run the coverage (need DB)
 * `make test-unit` will run all the test units  (need DB)
-* `make analyze-go-code` will run the [golangci](https://github.com/golangci/golangci-lint) static analysis tool, run it before sending your PR to github.
+* `make analyze-go-code` will run the [golangci](https://github.com/golangci/golangci-lint) static analysis tool, run it before sending your PR to github. The [golangci](https://golangci.com/r/github.com/fabric8-services/fabric8-build) check service will be the one taking care of checking your PR, so it can report nicely on your code if there is any issues.
 
 ### RUNNING
 

--- a/controller/pipeline_environments_blackbox_test.go
+++ b/controller/pipeline_environments_blackbox_test.go
@@ -31,9 +31,8 @@ type PipelineEnvironmentControllerSuite struct {
 	ctx  context.Context
 	ctx2 context.Context
 
-	ctrl     *controller.PipelineEnvironmentController
-	ctrl2    *controller.PipelineEnvironmentController
-	prodCtrl *controller.PipelineEnvironmentController
+	ctrl  *controller.PipelineEnvironmentController
+	ctrl2 *controller.PipelineEnvironmentController
 }
 
 func TestPipelineEnvironmentController(t *testing.T) {
@@ -114,7 +113,8 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		emptyPayload := &app.CreatePipelineEnvironmentsPayload{}
 		createCtxerr, rw := s.createPipelineEnvironmentCtrlNoErroring()
 		createCtxerr.Payload = emptyPayload
-		s.ctrl2.Create(createCtxerr)
+		jerr := s.ctrl2.Create(createCtxerr)
+		require.Nil(t, jerr)
 		require.Equal(t, 400, rw.Code)
 	})
 


### PR DESCRIPTION
Error were theses :

```bash
>>--- RESULTS: GOLANGCI CODE ANALYSIS ---<<
controller/pipeline_environments_blackbox_test.go:36:2: `prodCtrl` is unused (structcheck)
    prodCtrl *controller.PipelineEnvironmentController
    ^
controller/pipeline_environments_blackbox_test.go:117:17: Error return value of `s.ctrl2.Create` is not checked (errcheck)
        s.ctrl2.Create(createCtxerr)
                      ^
make: *** [analyze-go-code] Error 1
```

This closes openshiftio/openshift.io#4590 and closes #121