### PR TITLE
Make sure to wait that the database is up

### DIFF
--- a/openshift/deploy-openshift-dev.sh
+++ b/openshift/deploy-openshift-dev.sh
@@ -58,7 +58,14 @@ function deploy_db() {
     sleep 2
 
     for x in ${DBS};do
-        oc rsh dc/${DC_DB} psql -c  "create database ${x};"
+        cnt=0
+        while True;do
+            [[ ${cnt} -ge 20 ]] && { echo "Cannot connect to database"; exit 1 ; }
+            oc rsh dc/${DC_DB} psql -c  "create database ${x};" && break || {
+                cnt+=1
+                sleep 5
+           }
+        done
     done
 
 }


### PR DESCRIPTION
Make sure we are waiting enough that the database is up since we previously
would have not given enough time to shutdown.