### PR TITLE
Refactor show and Implement List API

### DIFF
--- a/build/pipelineenv_blackbox_test.go
+++ b/build/pipelineenv_blackbox_test.go
@@ -65,10 +65,25 @@ func (s *BuildRepositorySuite) TestShow() {
 	require.NoError(s.T(), err)
 	require.NotNil(s.T(), newEnv)
 
-	env, err := s.buildRepo.Load(context.Background(), spaceID)
+	env, err := s.buildRepo.Load(context.Background(), newEnv.ID)
 	require.NoError(s.T(), err)
 	assert.NotNil(s.T(), env)
 	assert.Equal(s.T(), newEnv.ID, env.ID)
+}
+
+func (s *BuildRepositorySuite) TestList() {
+	spaceID, envUUID, envUUID2 := uuid.NewV4(), uuid.NewV4(), uuid.NewV4()
+	newEnv, err := s.buildRepo.Create(context.Background(), newPipeline("pipelineShow", spaceID, envUUID))
+	newEnv2, err2 := s.buildRepo.Create(context.Background(), newPipeline("pipelineShow2", spaceID, envUUID2))
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), err2)
+	require.NotNil(s.T(), newEnv)
+	require.NotNil(s.T(), newEnv2)
+
+	env, err := s.buildRepo.List(context.Background(), spaceID)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), env)
+	assert.Equal(s.T(), 2, len(env))
 }
 
 func newPipeline(name string, spaceID, envUUID uuid.UUID) *build.Pipeline {

--- a/controller/pipeline_environments_blackbox_test.go
+++ b/controller/pipeline_environments_blackbox_test.go
@@ -279,7 +279,7 @@ func (s *PipelineEnvironmentControllerSuite) TestShow() {
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
 		require.NotNil(t, newEnv)
 
-		_, env := test.ShowPipelineEnvironmentsOK(t, s.ctx2, s.svc2, s.ctrl2, spaceID)
+		_, env := test.ShowPipelineEnvironmentsOK(t, s.ctx2, s.svc2, s.ctrl2, *newEnv.Data.ID)
 		assert.NotNil(t, env)
 		assert.Equal(t, newEnv.Data.ID, env.Data.ID)
 	})
@@ -287,6 +287,32 @@ func (s *PipelineEnvironmentControllerSuite) TestShow() {
 	s.T().Run("not_found", func(t *testing.T) {
 		envID := uuid.NewV4()
 		_, err := test.ShowPipelineEnvironmentsNotFound(t, s.ctx2, s.svc2, s.ctrl2, envID)
+		assert.NotNil(t, err)
+	})
+}
+
+func (s *PipelineEnvironmentControllerSuite) TestList() {
+	s.T().Run("ok", func(t *testing.T) {
+		spaceID := uuid.NewV4()
+		env1ID := uuid.NewV4()
+		env2ID := uuid.NewV4()
+		s.createGockONSpace(spaceID, "space1")
+		s.createGockONEnvList(spaceID, env1ID, env2ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-show", env1ID)
+		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
+		require.NotNil(t, newEnv)
+		payload2 := newPipelineEnvironmentPayload("osio-stage-show", env2ID)
+		_, newEnv2 := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload2)
+		require.NotNil(t, newEnv2)
+
+		_, env := test.ListPipelineEnvironmentsOK(t, s.ctx2, s.svc2, s.ctrl2, spaceID)
+		assert.NotNil(t, env)
+		assert.Equal(t, 2, len(env.Data))
+	})
+
+	s.T().Run("space_not_found", func(t *testing.T) {
+		spaceID := uuid.NewV4()
+		_, err := test.ListPipelineEnvironmentsInternalServerError(t, s.ctx2, s.svc2, s.ctrl2, spaceID)
 		assert.NotNil(t, err)
 	})
 }

--- a/design/media_types.go
+++ b/design/media_types.go
@@ -1,0 +1,14 @@
+package design
+
+import (
+	d "github.com/goadesign/goa/design"
+	a "github.com/goadesign/goa/design/apidsl"
+)
+
+var pagingLinks = a.Type("pagingLinks", func() {
+	a.Attribute("prev", d.String)
+	a.Attribute("next", d.String)
+	a.Attribute("first", d.String)
+	a.Attribute("last", d.String)
+	a.Attribute("filters", d.String)
+})

--- a/design/pipelineenv.go
+++ b/design/pipelineenv.go
@@ -28,47 +28,70 @@ var pipelineEnv = a.Type("PipelineEnvironments", func() {
 	a.Required("name", "environments")
 })
 
+var pipelineEnvListMeta = a.Type("PipelineEnvironmentListMeta", func() {
+	a.Attribute("totalCount", d.Integer)
+	a.Required("totalCount")
+})
+
 var pipelineEnvSingle = JSONSingle(
 	"PipelineEnvironment", "Holds a single pipeline environment map",
 	pipelineEnv,
 	nil)
 
+var pipelineEnvList = JSONList(
+	"PipelineEnvironments", "Holds the list of pipeline environment map",
+	pipelineEnv,
+	pagingLinks,
+	pipelineEnvListMeta)
+
 var _ = a.Resource("PipelineEnvironments", func() {
 	a.Action("create", func() {
+		a.Description("Create pipeline environment map")
+		a.Params(func() {
+			a.Param("spaceID", d.UUID, "Space ID for the pipeline environment map")
+		})
 		a.Routing(
 			a.POST("/spaces/:spaceID/pipeline-environments"),
 		)
-		a.Description("Create environment")
-		a.Params(func() {
-			a.Param("spaceID", d.UUID, "UUID of the space")
-		})
 		a.Payload(pipelineEnvSingle)
 		a.Response(d.Created, pipelineEnvSingle)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
 		a.Response(d.MethodNotAllowed, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 		a.Response(d.Conflict, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 	})
 
-	a.Action("show", func() {
-		a.Description("Retrieve pipeline environment map (as JSONAPI) for the given space ID.")
+	a.Action("list", func() {
+		a.Description("Retrieve list of pipeline environment maps (as JSONAPI) for the given space ID.")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "Space ID for the pipeline environment map")
 		})
-
 		a.Routing(
 			a.GET("/spaces/:spaceID/pipeline-environments"),
 		)
+		a.Response(d.OK, pipelineEnvList)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+	})
 
+	a.Action("show", func() {
+		a.Description("Retrieve pipeline environment map (as JSONAPI) for the given ID.")
 		a.Params(func() {
-			a.Param("spaceID", d.UUID, "UUID of the space")
+			a.Param("ID", d.UUID, "ID of the pipeline environment map")
 		})
-
+		a.Routing(
+			a.GET("/pipeline-environments/:ID"),
+		)
 		a.Response(d.OK, pipelineEnvSingle)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 
 })


### PR DESCRIPTION
This patch will refactor the show api to return the
pip-env map of the id provided inspite of assuming
one in a space and always return the first

Also implement list api to return all the pip-env maps
in a space.

Implement tests for list api

Fixes https://github.com/fabric8-services/fabric8-build/issues/142
Fixes https://github.com/openshiftio/openshift.io/issues/4638