### PR TITLE
Move from epel-testing to epel-release

### DIFF
--- a/.cico/setup.sh
+++ b/.cico/setup.sh
@@ -28,8 +28,8 @@ function setup() {
     # We need to disable selinux for now, XXX
     /usr/sbin/setenforce 0 || :
 
-    yum install epel-release --enablerepo=extras -y
-    yum -y install --enablerepo=epel-testing podman make golang git
+    yum install epel-release -y
+    yum -y install --enablerepo=epel podman make golang git
 
     mkdir -p $(dirname ${REPO_PATH})
     cp -a ${HOME}/payload ${REPO_PATH}


### PR DESCRIPTION
This patch is to use go library from epel-release
in spite of epel-testing

Fix related to https://github.com/openshiftio/openshift.io/issues/4618