### PR TITLE
Add api to update pip-env map

### DIFF
--- a/build/pipelineenv.go
+++ b/build/pipelineenv.go
@@ -14,6 +14,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 )
 
+// Pipeline Env Map Structure
 type Pipeline struct {
 	gormsupport.Lifecycle
 	ID          uuid.UUID  `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
@@ -22,6 +23,7 @@ type Pipeline struct {
 	Environment []Environment
 }
 
+// Environment Structure
 type Environment struct {
 	gormsupport.Lifecycle
 	EnvironmentID *uuid.UUID `sql:"type:uuid"`
@@ -33,6 +35,7 @@ type Repository interface {
 	Create(ctx context.Context, pipl *Pipeline) (*Pipeline, error)
 	Load(ctx context.Context, ID uuid.UUID) (*Pipeline, error)
 	List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeline, error)
+	Save(ctx context.Context, ppl *Pipeline) (*Pipeline, error)
 }
 
 type GormRepository struct {
@@ -45,6 +48,7 @@ func NewRepository(db *gorm.DB) *GormRepository {
 	}
 }
 
+// Create a Pipeline Env Map
 func (r *GormRepository) Create(ctx context.Context, pipl *Pipeline) (*Pipeline, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "create"}, time.Now())
 
@@ -62,6 +66,7 @@ func (r *GormRepository) Create(ctx context.Context, pipl *Pipeline) (*Pipeline,
 	return pipl, nil
 }
 
+// List all Pipeline Env Map in a space
 func (r *GormRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeline, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "list"}, time.Now())
 	var rows []*Pipeline
@@ -81,6 +86,7 @@ func (r *GormRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeli
 	return rows, nil
 }
 
+// Load a Pipeline Env of given ID
 func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Pipeline, error) {
 	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "load"}, time.Now())
 	ppl := Pipeline{}
@@ -98,4 +104,36 @@ func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Pipeline, err
 		return nil, errors.NewInternalError(ctx, tx.Error)
 	}
 	return &ppl, nil
+}
+
+// Save the given Pipeline Env Map
+func (r *GormRepository) Save(ctx context.Context, p *Pipeline) (*Pipeline, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "save"}, time.Now())
+	ppl, err := r.Load(ctx, p.ID)
+	if err != nil {
+		log.Error(ctx, map[string]interface{}{
+			"pipeline_environment_map_id": p.ID.String(),
+			"err":                         err,
+		}, "unable to load pipeline environment map")
+		return nil, errors.NewInternalError(ctx, err)
+	}
+
+	tx := r.db.Model(ppl).Updates(p)
+	if err := tx.Error; err != nil {
+		if gormsupport.IsCheckViolation(tx.Error, "pipelineEnvironment_name_check") {
+			return nil, errors.NewBadParameterError("Name", p.Name).Expected("not empty")
+		}
+		if gormsupport.IsUniqueViolation(tx.Error, "pipelineEnvironment_name_id") {
+			return nil, errors.NewBadParameterError("Name", p.Name).Expected("unique")
+		}
+		log.Error(ctx, map[string]interface{}{
+			"err":                         err,
+			"pipeline_environment_map_id": p.ID,
+		}, "unable to update pipeline environment map")
+		return nil, errors.NewInternalError(ctx, err)
+	}
+	log.Info(ctx, map[string]interface{}{
+		"pipelineEnvironment_id": p.ID,
+	}, "pipelineEnvironment map updated successfully")
+	return p, nil
 }

--- a/build/pipelineenv_blackbox_test.go
+++ b/build/pipelineenv_blackbox_test.go
@@ -91,10 +91,41 @@ func (s *BuildRepositorySuite) TestList() {
 	assert.Equal(s.T(), 0, len(env2))
 }
 
+func (s *BuildRepositorySuite) TestSave() {
+	spaceID, envUUID, envUUID2, envUUID3 := uuid.NewV4(), uuid.NewV4(), uuid.NewV4(), uuid.NewV4()
+	pipeline := newPipeline("pipelineShow", spaceID, envUUID)
+	newEnv, err := s.buildRepo.Create(context.Background(), pipeline)
+	newEnv2, err2 := s.buildRepo.Create(context.Background(), newPipeline("pipelineShow2", spaceID, envUUID2))
+	require.NoError(s.T(), err)
+	require.NoError(s.T(), err2)
+	require.NotNil(s.T(), newEnv)
+	require.NotNil(s.T(), newEnv2)
+
+	pipelineUpdate := updatePipeline(pipeline, envUUID3)
+	env, err := s.buildRepo.Save(context.Background(), pipelineUpdate)
+	require.NoError(s.T(), err)
+	assert.NotNil(s.T(), env)
+	require.NotNil(s.T(), env)
+	require.NotNil(s.T(), env)
+	assert.Equal(s.T(), envUUID3, *(env.Environment[0].EnvironmentID))
+}
+
 func newPipeline(name string, spaceID, envUUID uuid.UUID) *build.Pipeline {
 	ppl := &build.Pipeline{
 		Name:    &name,
 		SpaceID: &spaceID,
+		Environment: []build.Environment{
+			{EnvironmentID: &envUUID},
+		},
+	}
+	return ppl
+}
+
+func updatePipeline(pipeline *build.Pipeline, envUUID uuid.UUID) *build.Pipeline {
+	ppl := &build.Pipeline{
+		Name:    pipeline.Name,
+		SpaceID: pipeline.SpaceID,
+		ID:      pipeline.ID,
 		Environment: []build.Environment{
 			{EnvironmentID: &envUUID},
 		},

--- a/controller/pipeline_environments_blackbox_test.go
+++ b/controller/pipeline_environments_blackbox_test.go
@@ -188,7 +188,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		env2ID := uuid.NewV4()
 		s.createGockONSpace(space1ID, "space1")
 		s.createGockONEnvList(space1ID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage-create", env1ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-create", space1ID, env1ID)
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, space1ID, payload)
 		assert.NotNil(t, newEnv)
 		assert.NotNil(t, newEnv.Data.ID)
@@ -198,7 +198,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		space2ID := uuid.NewV4()
 		s.createGockONSpace(space2ID, "space2")
 		s.createGockONEnvList(space2ID, env1ID, env2ID)
-		payload = newPipelineEnvironmentPayload("osio-stage-create", env1ID)
+		payload = newPipelineEnvironmentPayload("osio-stage-create", space2ID, env1ID)
 		_, newEnv = test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, space2ID, payload)
 		assert.NotNil(t, newEnv)
 		assert.NotNil(t, newEnv.Data.ID)
@@ -212,7 +212,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 
 		s.createGockONSpace(space1ID, "space1")
 		s.createGockONEnvList(space1ID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage-create-conflict", env1ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-create-conflict", space1ID, env1ID)
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, space1ID, payload)
 		assert.NotNil(t, newEnv)
 
@@ -233,7 +233,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		gock.New("http://witservice").
 			Get("/api/spaces/" + failSpaceID.String()).
 			Reply(404)
-		payload = newPipelineEnvironmentPayload("space-not-found", env1ID)
+		payload = newPipelineEnvironmentPayload("space-not-found", failSpaceID, env1ID)
 		response, err = test.CreatePipelineEnvironmentsNotFound(t, s.ctx2, s.svc2, s.ctrl2, failSpaceID, payload)
 		require.NotNil(t, response.Header().Get("Location"))
 		assert.Regexp(s.T(), ".*not_found.*", err.Errors)
@@ -242,7 +242,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		gock.New("http://witservice").
 			Get("/api/spaces/" + failSpaceID.String()).
 			Reply(422)
-		payload = newPipelineEnvironmentPayload("space-unkown-error", env1ID)
+		payload = newPipelineEnvironmentPayload("space-unkown-error", failSpaceID, env1ID)
 		response, err = test.CreatePipelineEnvironmentsInternalServerError(t, s.ctx2, s.svc2, s.ctrl2, failSpaceID, payload)
 		require.NotNil(t, response.Header().Get("Location"))
 		assert.Regexp(s.T(), ".*unknown_error.*", err.Errors)
@@ -250,7 +250,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		failEnvID := uuid.NewV4()
 		s.createGockONSpace(space1ID, "space1")
 		s.createGockONEnvList(space1ID, env1ID, env2ID)
-		payload = newPipelineEnvironmentPayload("env-not-found", failEnvID)
+		payload = newPipelineEnvironmentPayload("env-not-found", space1ID, failEnvID)
 		response, err = test.CreatePipelineEnvironmentsNotFound(t, s.ctx2, s.svc2, s.ctrl2, space1ID, payload)
 		require.NotNil(t, response.Header().Get("Location"))
 		assert.Regexp(s.T(), ".*not_found.*", err.Errors)
@@ -262,7 +262,7 @@ func (s *PipelineEnvironmentControllerSuite) TestCreate() {
 		env2ID := uuid.NewV4()
 		s.createGockONSpace(space1ID, "space1")
 		s.createGockONEnvList(space1ID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage", env2ID)
+		payload := newPipelineEnvironmentPayload("osio-stage", space1ID, env2ID)
 		_, err := test.CreatePipelineEnvironmentsUnauthorized(t, s.ctx, s.svc, s.ctrl, space1ID, payload)
 		assert.NotNil(t, err)
 	})
@@ -275,7 +275,7 @@ func (s *PipelineEnvironmentControllerSuite) TestShow() {
 		env2ID := uuid.NewV4()
 		s.createGockONSpace(spaceID, "space1")
 		s.createGockONEnvList(spaceID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage-show", env1ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-show", spaceID, env1ID)
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
 		require.NotNil(t, newEnv)
 
@@ -290,7 +290,7 @@ func (s *PipelineEnvironmentControllerSuite) TestShow() {
 		env2ID := uuid.NewV4()
 		s.createGockONSpace(spaceID, "space1")
 		s.createGockONEnvList(spaceID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage-show", env1ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-show", spaceID, env1ID)
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
 		require.NotNil(t, newEnv)
 
@@ -306,12 +306,12 @@ func (s *PipelineEnvironmentControllerSuite) TestList() {
 		env2ID := uuid.NewV4()
 		s.createGockONSpace(spaceID, "space1")
 		s.createGockONEnvList(spaceID, env1ID, env2ID)
-		payload := newPipelineEnvironmentPayload("osio-stage-show", env1ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-show", spaceID, env1ID)
 		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
 		require.NotNil(t, newEnv)
 		s.createGockONSpace(spaceID, "space1")
 		s.createGockONEnvList(spaceID, env1ID, env2ID)
-		payload2 := newPipelineEnvironmentPayload("osio-stage-show2", env2ID)
+		payload2 := newPipelineEnvironmentPayload("osio-stage-show2", spaceID, env2ID)
 		_, newEnv2 := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload2)
 		require.NotNil(t, newEnv2)
 
@@ -328,10 +328,60 @@ func (s *PipelineEnvironmentControllerSuite) TestList() {
 	})
 }
 
-func newPipelineEnvironmentPayload(name string, envUUID uuid.UUID) *app.CreatePipelineEnvironmentsPayload {
+func (s *PipelineEnvironmentControllerSuite) TestUpdate() {
+	s.T().Run("ok", func(t *testing.T) {
+		spaceID := uuid.NewV4()
+		env1ID := uuid.NewV4()
+		env2ID := uuid.NewV4()
+		s.createGockONSpace(spaceID, "space1")
+		s.createGockONEnvList(spaceID, env1ID, env2ID)
+		payload := newPipelineEnvironmentPayload("osio-stage-update", spaceID, env1ID)
+		_, newEnv := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, spaceID, payload)
+		require.NotNil(t, newEnv)
+		s.createGockONSpace(spaceID, "space1")
+		s.createGockONEnvList(spaceID, env1ID, env2ID)
+		payload2 := updatePipelineEnvironmentPayload(payload, env2ID)
+		_, newEnv2 := test.UpdatePipelineEnvironmentsOK(t, s.ctx2, s.svc2, s.ctrl2, *newEnv.Data.ID, payload2)
+		require.NotNil(t, newEnv2)
+		assert.Equal(t, env2ID, *(newEnv2.Data.Environments[0].EnvUUID))
+	})
+
+	s.T().Run("unauthorized", func(t *testing.T) {
+		space1ID := uuid.NewV4()
+		env1ID := uuid.NewV4()
+		env2ID := uuid.NewV4()
+		s.createGockONSpace(space1ID, "space1")
+		s.createGockONEnvList(space1ID, env1ID, env2ID)
+		payload := newPipelineEnvironmentPayload("osio-stage", space1ID, env2ID)
+		_, env := test.CreatePipelineEnvironmentsCreated(t, s.ctx2, s.svc2, s.ctrl2, space1ID, payload)
+		assert.NotNil(t, env)
+		s.createGockONSpace(space1ID, "space1")
+		s.createGockONEnvList(space1ID, env1ID, env2ID)
+		uPayload := updatePipelineEnvironmentPayload(payload, env1ID)
+		_, err := test.UpdatePipelineEnvironmentsUnauthorized(t, s.ctx, s.svc, s.ctrl2, *env.Data.ID, uPayload)
+		assert.NotNil(t, err)
+	})
+}
+
+func newPipelineEnvironmentPayload(name string, spaceID uuid.UUID, envUUID uuid.UUID) *app.CreatePipelineEnvironmentsPayload {
 	payload := &app.CreatePipelineEnvironmentsPayload{
 		Data: &app.PipelineEnvironments{
-			Name: name,
+			Name:    name,
+			SpaceID: &spaceID,
+			Environments: []*app.EnvironmentAttributes{
+				{EnvUUID: &envUUID},
+			},
+		},
+	}
+	return payload
+}
+
+func updatePipelineEnvironmentPayload(pEnv *app.CreatePipelineEnvironmentsPayload, envUUID uuid.UUID) *app.UpdatePipelineEnvironmentsPayload {
+	payload := &app.UpdatePipelineEnvironmentsPayload{
+		Data: &app.PipelineEnvironments{
+			Name:    pEnv.Data.Name,
+			SpaceID: pEnv.Data.SpaceID,
+			ID:      pEnv.Data.ID,
 			Environments: []*app.EnvironmentAttributes{
 				{EnvUUID: &envUUID},
 			},

--- a/design/pipelineenv.go
+++ b/design/pipelineenv.go
@@ -94,4 +94,23 @@ var _ = a.Resource("PipelineEnvironments", func() {
 		a.Response(d.Forbidden, JSONAPIErrors)
 	})
 
+	a.Action("update", func() {
+		a.Description("Update the pipeline environment map for the given ID.")
+		a.Params(func() {
+			a.Param("ID", d.UUID, "ID of the pipeline environment map to update")
+		})
+		a.Routing(
+			a.PATCH("/pipeline-environments/:ID"),
+		)
+		a.Payload(pipelineEnvSingle)
+		a.Response(d.OK, pipelineEnvSingle)
+		a.Response(d.InternalServerError, JSONAPIErrors)
+		a.Response(d.NotFound, JSONAPIErrors)
+		a.Response(d.BadRequest, JSONAPIErrors)
+		a.Response(d.Unauthorized, JSONAPIErrors)
+		a.Response(d.MethodNotAllowed, JSONAPIErrors)
+		a.Response(d.Conflict, JSONAPIErrors)
+		a.Response(d.Forbidden, JSONAPIErrors)
+	})
+
 })


### PR DESCRIPTION
This will add a api to update the given
pipeline-environment map.
Adds test related to test
Adds the validation of payload data
in create and update api

Fixes #139
Fixes openshiftio/openshift.io#4614