### PR TITLE
Refactor Structs and Schema

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -3,7 +3,7 @@ package application
 import "github.com/fabric8-services/fabric8-build/build"
 
 type Application interface {
-	Pipeline() build.Repository
+	PipelineEnvMap() build.Repository
 }
 
 type Transaction interface {

--- a/build/pipelineenv.go
+++ b/build/pipelineenv.go
@@ -15,27 +15,26 @@ import (
 )
 
 // Pipeline Env Map Structure
-type Pipeline struct {
+type PipelineEnvMap struct {
 	gormsupport.Lifecycle
-	ID          uuid.UUID  `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
-	Name        *string    `gorm:"not null;unique"` // Set field as not nullable and unique
-	SpaceID     *uuid.UUID `sql:"type:uuid"`
-	Environment []Environment
+	ID           uuid.UUID  `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	Name         *string    `gorm:"not null;unique"` // Set field as not nullable and unique
+	SpaceID      *uuid.UUID `sql:"type:uuid"`
+	Environments []PipelineEnvironment
 }
 
-// Environment Structure
-type Environment struct {
+// Pipeline Environment contains entries of all PipelineEnvironmentMap-Environment associations
+type PipelineEnvironment struct {
 	gormsupport.Lifecycle
-	EnvironmentID *uuid.UUID `sql:"type:uuid"`
-	PipelineID    uuid.UUID  `sql:"type:uuid"`
-	ID            uuid.UUID  `sql:"type:uuid default uuid_generate_v4()" gorm:"primary_key"`
+	EnvironmentID    *uuid.UUID `sql:"type:uuid"`
+	PipelineEnvMapID uuid.UUID  `sql:"type:uuid" gorm:"column:pipelineenvmap_id"`
 }
 
 type Repository interface {
-	Create(ctx context.Context, pipl *Pipeline) (*Pipeline, error)
-	Load(ctx context.Context, ID uuid.UUID) (*Pipeline, error)
-	List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeline, error)
-	Save(ctx context.Context, ppl *Pipeline) (*Pipeline, error)
+	Create(ctx context.Context, pipEnvMap *PipelineEnvMap) (*PipelineEnvMap, error)
+	Load(ctx context.Context, ID uuid.UUID) (*PipelineEnvMap, error)
+	List(ctx context.Context, spaceID uuid.UUID) ([]*PipelineEnvMap, error)
+	Save(ctx context.Context, pipEnvMap *PipelineEnvMap) (*PipelineEnvMap, error)
 }
 
 type GormRepository struct {
@@ -49,13 +48,13 @@ func NewRepository(db *gorm.DB) *GormRepository {
 }
 
 // Create a Pipeline Env Map
-func (r *GormRepository) Create(ctx context.Context, pipl *Pipeline) (*Pipeline, error) {
-	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "create"}, time.Now())
+func (r *GormRepository) Create(ctx context.Context, pipEnvMap *PipelineEnvMap) (*PipelineEnvMap, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "pipeline_env_maps", "create"}, time.Now())
 
-	err := r.db.Create(pipl).Error
+	err := r.db.Create(pipEnvMap).Error
 	if err != nil {
-		if gormsupport.IsUniqueViolation(err, "pipelines_name_space_id_key") {
-			return nil, errors.NewDataConflictError(fmt.Sprintf("pipeline_environment_map_name %s with spaceID %s already exists", *pipl.Name, pipl.SpaceID))
+		if gormsupport.IsUniqueViolation(err, "pipeline_env_maps_name_space_id_key") {
+			return nil, errors.NewDataConflictError(fmt.Sprintf("pipeline_environment_map_name %s with spaceID %s already exists", *pipEnvMap.Name, *pipEnvMap.SpaceID))
 		}
 
 		log.Error(ctx, map[string]interface{}{"err": err},
@@ -63,14 +62,14 @@ func (r *GormRepository) Create(ctx context.Context, pipl *Pipeline) (*Pipeline,
 		return nil, errs.WithStack(err)
 	}
 
-	return pipl, nil
+	return pipEnvMap, nil
 }
 
 // List all Pipeline Env Map in a space
-func (r *GormRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeline, error) {
-	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "list"}, time.Now())
-	var rows []*Pipeline
-	tx := r.db.Model(&Pipeline{}).Where("space_id = ?", spaceID).Preload("Environment").Find(&rows)
+func (r *GormRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*PipelineEnvMap, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "pipeline_env_maps", "list"}, time.Now())
+	var rows []*PipelineEnvMap
+	tx := r.db.Model(&PipelineEnvMap{}).Where("space_id = ?", spaceID).Preload("Environments").Find(&rows)
 	if tx.RecordNotFound() {
 		log.Error(ctx, map[string]interface{}{"space_id": spaceID.String()},
 			"state or known referer was empty")
@@ -86,11 +85,11 @@ func (r *GormRepository) List(ctx context.Context, spaceID uuid.UUID) ([]*Pipeli
 	return rows, nil
 }
 
-// Load a Pipeline Env of given ID
-func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Pipeline, error) {
-	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "load"}, time.Now())
-	ppl := Pipeline{}
-	tx := r.db.Model(&Pipeline{}).Where("id = ?", ID).Preload("Environment").First(&ppl)
+// Load a Pipeline Env Map of given ID
+func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*PipelineEnvMap, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "pipeline_env_maps", "load"}, time.Now())
+	ppl := PipelineEnvMap{}
+	tx := r.db.Model(&PipelineEnvMap{}).Where("id = ?", ID).Preload("Environments").First(&ppl)
 	if tx.RecordNotFound() {
 		log.Error(ctx, map[string]interface{}{"id": ID.String()},
 			"state or known referer was empty")
@@ -107,8 +106,8 @@ func (r *GormRepository) Load(ctx context.Context, ID uuid.UUID) (*Pipeline, err
 }
 
 // Save the given Pipeline Env Map
-func (r *GormRepository) Save(ctx context.Context, p *Pipeline) (*Pipeline, error) {
-	defer goa.MeasureSince([]string{"goa", "db", "pipeline", "save"}, time.Now())
+func (r *GormRepository) Save(ctx context.Context, p *PipelineEnvMap) (*PipelineEnvMap, error) {
+	defer goa.MeasureSince([]string{"goa", "db", "pipeline_env_maps", "save"}, time.Now())
 	ppl, err := r.Load(ctx, p.ID)
 	if err != nil {
 		log.Error(ctx, map[string]interface{}{
@@ -120,10 +119,10 @@ func (r *GormRepository) Save(ctx context.Context, p *Pipeline) (*Pipeline, erro
 
 	tx := r.db.Model(ppl).Updates(p)
 	if err := tx.Error; err != nil {
-		if gormsupport.IsCheckViolation(tx.Error, "pipelineEnvironment_name_check") {
+		if gormsupport.IsCheckViolation(tx.Error, "pipelineEnvMap_name_check") {
 			return nil, errors.NewBadParameterError("Name", p.Name).Expected("not empty")
 		}
-		if gormsupport.IsUniqueViolation(tx.Error, "pipelineEnvironment_name_id") {
+		if gormsupport.IsUniqueViolation(tx.Error, "pipelineEnvMap_name_id") {
 			return nil, errors.NewBadParameterError("Name", p.Name).Expected("unique")
 		}
 		log.Error(ctx, map[string]interface{}{

--- a/design/pipelineenv.go
+++ b/design/pipelineenv.go
@@ -12,49 +12,49 @@ var envAttrs = a.Type("EnvironmentAttributes", func() {
 	})
 })
 
-var pipelineEnv = a.Type("PipelineEnvironments", func() {
+var pipelineEnvMap = a.Type("PipelineEnvironmentMaps", func() {
 	a.Description(`JSONAPI store for data of pipeline environments.`)
-	a.Attribute("id", d.UUID, "ID of the pipeline environment", func() {
+	a.Attribute("id", d.UUID, "ID of the pipeline environment map", func() {
 		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
 	})
-	a.Attribute("spaceID", d.UUID, "ID of the pipeline environment", func() {
+	a.Attribute("spaceID", d.UUID, "ID of the pipeline environment map", func() {
 		a.Example("40bbdd3d-8b5d-4fd6-ac90-7236b669af04")
 	})
 	a.Attribute("name", d.String, "The environment name", func() {
 		a.Example("myapp-stage")
 	})
-	a.Attribute("environments", a.ArrayOf(envAttrs), "An array of environMents")
+	a.Attribute("environments", a.ArrayOf(envAttrs), "An array of environments")
 	a.Attribute("links", genericLinks)
 	a.Required("name", "environments")
 })
 
-var pipelineEnvListMeta = a.Type("PipelineEnvironmentListMeta", func() {
+var pipelineEnvMapListMeta = a.Type("PipelineEnvironmentListMeta", func() {
 	a.Attribute("totalCount", d.Integer)
 	a.Required("totalCount")
 })
 
-var pipelineEnvSingle = JSONSingle(
-	"PipelineEnvironment", "Holds a single pipeline environment map",
-	pipelineEnv,
+var pipelineEnvMapSingle = JSONSingle(
+	"PipelineEnvironmentMap", "Holds a single pipeline environment map",
+	pipelineEnvMap,
 	nil)
 
-var pipelineEnvList = JSONList(
-	"PipelineEnvironments", "Holds the list of pipeline environment map",
-	pipelineEnv,
+var pipelineEnvMapList = JSONList(
+	"PipelineEnvironmentMaps", "Holds the list of pipeline environment map",
+	pipelineEnvMap,
 	pagingLinks,
-	pipelineEnvListMeta)
+	pipelineEnvMapListMeta)
 
-var _ = a.Resource("PipelineEnvironments", func() {
+var _ = a.Resource("PipelineEnvironmentMaps", func() {
 	a.Action("create", func() {
 		a.Description("Create pipeline environment map")
 		a.Params(func() {
 			a.Param("spaceID", d.UUID, "Space ID for the pipeline environment map")
 		})
 		a.Routing(
-			a.POST("/spaces/:spaceID/pipeline-environments"),
+			a.POST("/spaces/:spaceID/pipeline-environment-maps"),
 		)
-		a.Payload(pipelineEnvSingle)
-		a.Response(d.Created, pipelineEnvSingle)
+		a.Payload(pipelineEnvMapSingle)
+		a.Response(d.Created, pipelineEnvMapSingle)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
@@ -70,9 +70,9 @@ var _ = a.Resource("PipelineEnvironments", func() {
 			a.Param("spaceID", d.UUID, "Space ID for the pipeline environment map")
 		})
 		a.Routing(
-			a.GET("/spaces/:spaceID/pipeline-environments"),
+			a.GET("/spaces/:spaceID/pipeline-environment-maps"),
 		)
-		a.Response(d.OK, pipelineEnvList)
+		a.Response(d.OK, pipelineEnvMapList)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
@@ -85,9 +85,9 @@ var _ = a.Resource("PipelineEnvironments", func() {
 			a.Param("ID", d.UUID, "ID of the pipeline environment map")
 		})
 		a.Routing(
-			a.GET("/pipeline-environments/:ID"),
+			a.GET("/pipeline-environment-maps/:ID"),
 		)
-		a.Response(d.OK, pipelineEnvSingle)
+		a.Response(d.OK, pipelineEnvMapSingle)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.Unauthorized, JSONAPIErrors)
@@ -100,10 +100,10 @@ var _ = a.Resource("PipelineEnvironments", func() {
 			a.Param("ID", d.UUID, "ID of the pipeline environment map to update")
 		})
 		a.Routing(
-			a.PATCH("/pipeline-environments/:ID"),
+			a.PATCH("/pipeline-environment-maps/:ID"),
 		)
-		a.Payload(pipelineEnvSingle)
-		a.Response(d.OK, pipelineEnvSingle)
+		a.Payload(pipelineEnvMapSingle)
+		a.Response(d.OK, pipelineEnvMapSingle)
 		a.Response(d.InternalServerError, JSONAPIErrors)
 		a.Response(d.NotFound, JSONAPIErrors)
 		a.Response(d.BadRequest, JSONAPIErrors)

--- a/gormapp/gormapp.go
+++ b/gormapp/gormapp.go
@@ -93,6 +93,6 @@ func (g *GormTransaction) Rollback() error {
 	return errors.WithStack(err)
 }
 
-func (g *GormBase) Pipeline() build.Repository {
+func (g *GormBase) PipelineEnvMap() build.Repository {
 	return build.NewRepository(g.db)
 }

--- a/main.go
+++ b/main.go
@@ -142,8 +142,8 @@ func main() {
 	appDB := gormapp.NewGormDB(db)
 
 	// Mount the 'pipeline environment map' controller
-	pipelineEnvCtrl := controller.NewPipelineEnvironmentController(service, appDB, svcFactory)
-	app.MountPipelineEnvironmentsController(service, pipelineEnvCtrl)
+	pipelineEnvCtrl := controller.NewPipelineEnvironmentMapsController(service, appDB, svcFactory)
+	app.MountPipelineEnvironmentMapsController(service, pipelineEnvCtrl)
 
 	log.Logger().Infoln("Git Commit SHA: ", app.Commit)
 	log.Logger().Infoln("UTC Build Time: ", app.BuildTime)

--- a/migration/migration_blackbox_test.go
+++ b/migration/migration_blackbox_test.go
@@ -104,10 +104,10 @@ func checkMigration001(t *testing.T) {
 
 	pipeline_id := "80654c22-c378-40bc-a76e-33a4bcc45f79"
 	t.Run("insert ok", func(t *testing.T) {
-		_, err := sqlDB.Exec(`INSERT INTO pipelines (id, name, space_id) VALUES ('` +
+		_, err := sqlDB.Exec(`INSERT INTO pipeline_env_maps (id, name, space_id) VALUES ('` +
 			pipeline_id + `', 'pipeline1', uuid_generate_v4())`)
 		require.NoError(t, err)
-		_, err = sqlDB.Exec("INSERT INTO environments (environment_id, pipeline_id) VALUES (uuid_generate_v4(), '" +
+		_, err = sqlDB.Exec("INSERT INTO pipeline_environments (environment_id, pipelineenvmap_id) VALUES (uuid_generate_v4(), '" +
 			pipeline_id + "')")
 		require.NoError(t, err)
 

--- a/migration/sql-files/001-pipelineenv.sql
+++ b/migration/sql-files/001-pipelineenv.sql
@@ -1,6 +1,6 @@
 CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
 
-CREATE TABLE pipelines (
+CREATE TABLE pipeline_env_maps (
     created_at timestamp with time zone,
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
@@ -12,17 +12,15 @@ CREATE TABLE pipelines (
 );
 
 
-CREATE TABLE environments (
-    id uuid DEFAULT public.uuid_generate_v4() NOT NULL,
+CREATE TABLE pipeline_environments (
     created_at timestamp with time zone,
     updated_at timestamp with time zone,
     deleted_at timestamp with time zone,
     environment_id uuid NOT NULL,
-    pipeline_id uuid,
-    FOREIGN KEY (pipeline_id) REFERENCES pipelines(id),
-    PRIMARY KEY(id)
+    pipelineenvmap_id uuid,
+    FOREIGN KEY (pipelineenvmap_id) REFERENCES pipeline_env_maps(id)
 );
 
-CREATE INDEX environments_environment_id_idx ON environments USING BTREE (environment_id);
-CREATE INDEX pipelines_space_id_idx ON pipelines USING BTREE (space_id);
-CREATE INDEX environments_pipeline_id_idx ON environments USING BTREE (pipeline_id);
+CREATE INDEX pipeline_environments_environment_id_idx ON pipeline_environments USING BTREE (environment_id);
+CREATE INDEX pipeline_env_maps_space_id_idx ON pipeline_env_maps USING BTREE (space_id);
+CREATE INDEX pipeline_environments_pipelineenvmap_id_idx ON pipeline_environments USING BTREE (pipelineenvmap_id);


### PR DESCRIPTION
This patch will fix the naming convention of
the objects used.
Pipeline will be PipelineEnvMap and
Environment will be PipelineEnvironment as
that is containing the entries of all
associations of pipenvmap-environment

Removed the non required field ID in
pipelineenvironments table

Updated the db schema according to new name

Change api's to pipeline-environment-maps from
pipeline-environments

Refactor Controllers and Tests accordingly.

Fixes #153
Fixes openshiftio/openshift.io#4692